### PR TITLE
Settings slice refactor, part of #242

### DIFF
--- a/src/features/onboarding/Onboarding/Onboarding.js
+++ b/src/features/onboarding/Onboarding/Onboarding.js
@@ -8,7 +8,7 @@ import {
   FATHOM_ONBOARDING_4,
 } from "../../../constants"
 
-import { insertSetting } from "../../settings"
+import { setInitialCycleLength, addMensesTag } from "../../settings"
 import { upsertEntry } from "../../entries"
 
 import { cleanTag } from "../../utils/tags"
@@ -82,7 +82,7 @@ const Onboarding = () => {
       event.preventDefault()
     }
 
-    await dispatch(insertSetting("tag", values.tag))
+    await dispatch(addMensesTag(values.tag))
 
     handleNext()
     setIsPending(false)
@@ -96,7 +96,7 @@ const Onboarding = () => {
     }
 
     if (values.daysBetween) {
-      await dispatch(insertSetting("daysBetween", values.daysBetween))
+      await dispatch(setInitialCycleLength(values.daysBetween))
     }
 
     if (values.lastStart) {

--- a/src/features/settings/SettingsMensesTagForm.js
+++ b/src/features/settings/SettingsMensesTagForm.js
@@ -56,7 +56,7 @@ const SettingsMensesTagForm = ({ title, onDone, Component }) => {
       onDone()
     } else {
       setIsPending(true)
-      const { error } = await dispatch(addMensesTag({ tag: newTag }))
+      const { error } = await dispatch(addMensesTag(newTag))
       if (error) {
         setError(error)
       } else {

--- a/src/features/settings/index.js
+++ b/src/features/settings/index.js
@@ -1,4 +1,6 @@
 export { default as SettingsCard } from "./SettingsCard"
 export { default as SettingsMensesTagForm } from "./SettingsMensesTagForm"
 
+export { default as reducer } from "./slice"
+
 export * from "./slice"

--- a/src/features/settings/slice.js
+++ b/src/features/settings/slice.js
@@ -16,14 +16,10 @@ const DB_MENSES_TAG_KEY = "tag"
 const DB_CYCLE_LENGTH_KEY = "daysBetween"
 
 export const SETTINGS_STATUS = {
-  INITIAL: "[Settings] Initial",
-  OPENING: "[Settings] Opening",
-  OPENED: "[Settings] Opened",
-  FAILED: "[Settings] Failed",
-}
-
-export const SETTING_STATUS = {
-  PENDING: "[Setting] Pending",
+  INITIAL: `[${DB_NAME}] Initial`,
+  OPENING: `[${DB_NAME}] Opening`,
+  OPENED: `[${DB_NAME}] Opened`,
+  FAILED: `[${DB_NAME}] Failed`,
 }
 
 // Adaptor

--- a/src/features/settings/slice.js
+++ b/src/features/settings/slice.js
@@ -88,7 +88,7 @@ export const setInitialCycleLength = createAsyncThunk(
 
     await userbase.insertItem({
       databaseName: DB_NAME,
-      itemId: DB_MENSES_TAG_KEY,
+      itemId: DB_CYCLE_LENGTH_KEY,
       item: length,
     })
   }
@@ -157,10 +157,10 @@ export const selectMainMensesTag = createSelector(
 )
 
 export const selectInitialDaysBetween = (state) => {
-  const daysBetween = selectSetting(state, "daysBetween")
-  if (daysBetween) {
+  const length = selectSetting(state, DB_CYCLE_LENGTH_KEY)
+  if (length) {
     // Will for some be saved as string
-    return parseInt(DB_CYCLE_LENGTH_KEY, 10)
+    return parseInt(length, 10)
   }
 }
 

--- a/src/features/settings/slice.js
+++ b/src/features/settings/slice.js
@@ -40,6 +40,8 @@ export const initSettings = createAsyncThunk(
     await userbase.openDatabase({
       databaseName: DB_NAME,
       changeHandler: (items) => {
+        // Anytime there are changes to settings
+        // on the server changeHandler will be called.
         thunkAPI.dispatch({
           type: `${DB_NAME}/changed`,
           payload: { items },
@@ -62,12 +64,15 @@ export const addMensesTag = createAsyncThunk(
         item: tag,
       })
     } else {
+      // Add new tag and make sure we only store valid values,
+      // even potentially cleaning up invalid values already stored.
       const tags = [tag, ...textToTagArray(current.item)]
+      const updatedItem = tagArrayToText(tags)
 
       await userbase.updateItem({
         databaseName: DB_NAME,
         itemId: DB_MENSES_TAG_KEY,
-        item: tagArrayToText(tags),
+        item: updatedItem,
       })
     }
   }
@@ -155,7 +160,7 @@ export const selectMainMensesTag = createSelector(
 export const selectInitialDaysBetween = (state) => {
   const length = selectSetting(state, DB_CYCLE_LENGTH_KEY)
   if (length) {
-    // Will for some be saved as string
+    // Will for some early users be stored as a string
     return parseInt(length, 10)
   }
 }

--- a/src/features/settings/slice.js
+++ b/src/features/settings/slice.js
@@ -1,87 +1,151 @@
-import { createSelector, createAsyncThunk } from "@reduxjs/toolkit"
-import { keyBy, first, compact, uniq } from "lodash"
-
-import { SETTINGS_DATABASE } from "../../constants"
-
-import { cleanTag } from "../utils/tags"
-
 import {
-  insertItem,
-  upsertItem,
-  openDatabase,
-  selectDatabaseItems,
-  selectIsDatabaseLoading,
-} from "../database"
+  createSelector,
+  createAsyncThunk,
+  createEntityAdapter,
+  createSlice,
+} from "@reduxjs/toolkit"
+import userbase from "userbase-js"
+import { first, isNumber, isUndefined } from "lodash"
 
-const databaseName = SETTINGS_DATABASE.databaseName
+import { tagArrayToText, textToTagArray } from "./utils"
 
-// Actions
+const SLICE_NAME = "settings"
+const DB_NAME = SLICE_NAME
+const DB_ITEM = "setting"
+const DB_MENSES_TAG_KEY = "tag"
+const DB_CYCLE_LENGTH_KEY = "daysBetween"
 
-export const initSettings = () => openDatabase({ databaseName })
-
-export const insertSetting = (id, setting) => {
-  return insertItem({
-    databaseName,
-    itemId: id,
-    item: setting,
-  })
+export const SETTINGS_STATUS = {
+  INITIAL: "[Settings] Initial",
+  OPENING: "[Settings] Opening",
+  OPENED: "[Settings] Opened",
+  FAILED: "[Settings] Failed",
 }
 
-export const upsertSetting = (id, setting) => {
-  return upsertItem({
-    databaseName,
-    itemId: id,
-    item: setting,
-  })
+export const SETTING_STATUS = {
+  PENDING: "[Setting] Pending",
 }
 
-export const upsertMensesTags = (tags) => {
-  const validTags = uniq(compact(tags.map((tag) => cleanTag(tag))))
-  return upsertSetting("tag", validTags.join(","))
-}
+// Adaptor
 
-export const addMensesTag = createAsyncThunk(
-  "mensesTags/add",
-  async (arg, { getState, dispatch }) => {
-    const { tag } = arg
-    const mensesTags = selectMensesTags(getState())
-    return dispatch(upsertMensesTags([tag, ...mensesTags]))
+const settingsAdaptor = createEntityAdapter({
+  selectId: (setting) => setting.itemId,
+})
+
+const { selectById } = settingsAdaptor.getSelectors(
+  (state) => state[SLICE_NAME]
+)
+
+// Thunks
+
+export const initSettings = createAsyncThunk(
+  `${DB_NAME}/init`,
+  async (_, thunkAPI) => {
+    await userbase.openDatabase({
+      databaseName: DB_NAME,
+      changeHandler: (items) => {
+        thunkAPI.dispatch({
+          type: `${DB_NAME}/changed`,
+          payload: { items },
+        })
+      },
+    })
   }
 )
+
+export const addMensesTag = createAsyncThunk(
+  `${DB_ITEM}/upsert`,
+  async (payload, thunkAPI) => {
+    const tag = payload
+    const current = selectById(thunkAPI.getState(), DB_MENSES_TAG_KEY)
+
+    if (isUndefined(current)) {
+      await userbase.insertItem({
+        databaseName: DB_NAME,
+        itemId: DB_MENSES_TAG_KEY,
+        item: tag,
+      })
+    } else {
+      const tags = [tag, ...textToTagArray(current.item)]
+
+      await userbase.updateItem({
+        databaseName: DB_NAME,
+        itemId: DB_MENSES_TAG_KEY,
+        item: tagArrayToText(tags),
+      })
+    }
+  }
+)
+
+export const setInitialCycleLength = createAsyncThunk(
+  `${DB_ITEM}/upsert`,
+  async (payload) => {
+    const length = parseInt(payload)
+
+    if (!isNumber(length)) {
+      throw new Error("Length is not a number")
+    }
+
+    await userbase.insertItem({
+      databaseName: DB_NAME,
+      itemId: DB_MENSES_TAG_KEY,
+      item: length,
+    })
+  }
+)
+
+// Store
+
+const settingsSlice = createSlice({
+  name: SLICE_NAME,
+  initialState: settingsAdaptor.getInitialState({
+    status: SETTINGS_STATUS.INITIAL,
+  }),
+  reducers: {},
+  extraReducers: {
+    [initSettings.pending]: (state) => {
+      state.status = SETTINGS_STATUS.OPENING
+    },
+    [initSettings.fulfilled]: (state) => {
+      state.status = SETTINGS_STATUS.OPENED
+    },
+    [initSettings.rejected]: (state, { error }) => {
+      state.status = SETTINGS_STATUS.FAILED
+      state.error = error
+    },
+    [`${DB_NAME}/changed`]: (state, { payload }) => {
+      settingsAdaptor.setAll(state, payload.items)
+    },
+  },
+})
 
 // Selectors
 
-export const selectAreSettingsLoading = (state) => {
-  return selectIsDatabaseLoading(state, {
-    databaseName,
-  })
-}
+const selectSettingsSlice = (state) => state[SLICE_NAME]
 
-const selectId = (state, props) => props.id
-
-const selectItems = (state) => {
-  return selectDatabaseItems(state, { databaseName })
-}
-
-export const selectSettingsById = createSelector([selectItems], (items) => {
-  return keyBy(items, "itemId")
-})
-
-export const selectSetting = createSelector(
-  [selectSettingsById, selectId],
-  (settingsById, id) => {
-    return settingsById[id] && settingsById[id].item
+export const selectAreSettingsLoading = createSelector(
+  [selectSettingsSlice],
+  (slice) => {
+    return [SETTINGS_STATUS.INITIAL, SETTINGS_STATUS.OPENING].includes(
+      slice.status
+    )
   }
 )
 
+export const selectSetting = createSelector([selectById], (setting) => {
+  if (setting) {
+    return setting.item
+  }
+})
+
 export const selectMensesTagText = (state) => {
-  return selectSetting(state, { id: "tag" }) || ""
+  return selectSetting(state, DB_MENSES_TAG_KEY) || ""
 }
 
 export const selectMensesTags = createSelector(
   [selectMensesTagText],
   (mensesTagText) => {
-    return uniq(compact(mensesTagText.split(",").map((tag) => cleanTag(tag))))
+    return textToTagArray(mensesTagText)
   }
 )
 
@@ -93,9 +157,12 @@ export const selectMainMensesTag = createSelector(
 )
 
 export const selectInitialDaysBetween = (state) => {
-  const daysBetween = selectSetting(state, { id: "daysBetween" })
+  const daysBetween = selectSetting(state, "daysBetween")
   if (daysBetween) {
     // Will for some be saved as string
-    return parseInt(daysBetween, 10)
+    return parseInt(DB_CYCLE_LENGTH_KEY, 10)
   }
 }
+
+export const name = settingsSlice.name
+export default settingsSlice.reducer

--- a/src/features/settings/useSettings.js
+++ b/src/features/settings/useSettings.js
@@ -1,0 +1,6 @@
+const useSetting = () => {
+  const isLoading = is
+
+  const validTags = uniq(compact(tags.map((tag) => cleanTag(tag))))
+  return upsertSetting("tag", validTags.join(","))
+}

--- a/src/features/settings/utils.js
+++ b/src/features/settings/utils.js
@@ -1,0 +1,17 @@
+import { uniq, compact } from "lodash"
+import { cleanTag } from "../utils/tags"
+
+export const cleanTags = (tags) => {
+  const cleanedTags = tags.map((tag) => cleanTag(tag))
+  return uniq(compact(cleanedTags))
+}
+
+export const textToTagArray = (text) => {
+  const tags = text.split(",")
+  return cleanTags(tags)
+}
+
+export const tagArrayToText = (tags) => {
+  const cleanedTags = cleanTags(tags)
+  return cleanedTags.join(",")
+}

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -20,7 +20,11 @@ import {
   name as databaseSliceName,
 } from "./features/database"
 
-import { initSettings } from "./features/settings"
+import {
+  initSettings,
+  reducer as settingsReducer,
+  name as settingsSliceName,
+} from "./features/settings"
 import { initEntries } from "./features/entries"
 
 import { withTheme } from "./theme"
@@ -31,6 +35,7 @@ const store = configureStore({
     [authSliceName]: authReducer,
     [userSliceName]: userReducer,
     [databaseSliceName]: databaseReducer,
+    [settingsSliceName]: settingsReducer,
   }),
 })
 


### PR DESCRIPTION
I have completed the initial refactor of settings into its own seperate slice @SaraVieira.

When this is merged you may use the thunks `addMensesTag` and `setInitialCycleLength` in the onboarding instead of the more generic `insertSetting`.